### PR TITLE
Fix code scanning alert no. 11: Incorrect conversion between integer types

### DIFF
--- a/command/flags/config.go
+++ b/command/flags/config.go
@@ -212,8 +212,14 @@ func (u *UintValue) Set(v string) error {
 		u.v = new(uint)
 	}
 	parsed, err := strconv.ParseUint(v, 0, 64)
+	if err != nil {
+		return err
+	}
+	if parsed > uint64(^uint(0)) {
+		return fmt.Errorf("value out of range for uint: %v", parsed)
+	}
 	*(u.v) = (uint)(parsed)
-	return err
+	return nil
 }
 
 // String implements the flag.Value interface.


### PR DESCRIPTION
Fixes [https://github.com/zocog/hcp-consul/security/code-scanning/11](https://github.com/zocog/hcp-consul/security/code-scanning/11)

To fix the problem, we need to ensure that the value parsed from the string is within the bounds of the `uint` type before performing the conversion. This can be done by checking if the parsed value is less than or equal to the maximum value of the `uint` type. If the value exceeds this limit, we should handle the error appropriately.

1. Use the `strconv.ParseUint` function to parse the string with a bit size of 64.
2. Check if the parsed value is within the bounds of the `uint` type.
3. If the value is within bounds, perform the conversion; otherwise, return an error.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
